### PR TITLE
Support SoftI2CMaster implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ The `b` at the end means `b`right. The `r` at the end means `r`otated.
 // To use the TinyI2C library from https://github.com/technoblogy/tiny-i2c
 //#include <TinyI2CMaster.h>
 
+// To use the SoftI2CMaster library from https://github.com/felias-fogg/SoftI2CMaster
+// #define SCL_PIN PINB2
+// #define SCL_PORT PORTB
+// #define SDA_PIN PINB0
+// #define SDA_PORT PORTB
+// #include <SoftWire.h>
+
 // The blue OLED screen requires a long initialization on power on.
 // The code to wait for it to be ready uses 20 bytes of program storage space
 // If you are using a white OLED, this can be reclaimed by uncommenting

--- a/src/Tiny4kOLED.h
+++ b/src/Tiny4kOLED.h
@@ -14,6 +14,8 @@
 #include "Tiny4kOLED_TinyWireM.h"
 #elif defined(TinyI2CMaster_h)
 #include "Tiny4kOLED_tiny-i2c.h"
+#elif defined(_SOFTI2C_H)
+#include "Tiny4kOLED_SoftI2CMaster.h"
 #else
 #include <Wire.h>
 #include "Tiny4kOLED_Wire.h"

--- a/src/Tiny4kOLED_SoftI2CMaster.h
+++ b/src/Tiny4kOLED_SoftI2CMaster.h
@@ -1,0 +1,51 @@
+/*
+ * Tiny4kOLED - Drivers for SSD1306 controlled dot matrix OLED/PLED 128x32 displays
+ *
+ * Based on ssd1306xled, re-written and extended by Stephen Denne
+ * from 2017-04-25 at https://github.com/datacute/Tiny4kOLED
+ *
+ */
+#ifndef TINY4KOLED_SOFTI2CMASTER_H
+#define TINY4KOLED_SOFTI2CMASTER_H
+
+#include <SoftWire.h>
+#include "Tiny4kOLED_common.h"
+
+static bool wire_beginTransmission(void);
+static uint8_t wire_endTransmission(void);
+
+static SoftWire Wire = SoftWire();
+
+#ifndef TINY4KOLED_QUICK_BEGIN
+inline static bool check (void) {
+	const uint8_t noError = 0x00;
+	wire_beginTransmission();
+	return (wire_endTransmission()==noError);
+}
+#endif
+
+static void wire_begin(void) {
+	Wire.begin();
+#ifndef TINY4KOLED_QUICK_BEGIN
+	while (!check()) {
+		delay(10);
+	}
+#endif
+}
+
+static bool wire_beginTransmission(void) {
+	Wire.beginTransmission(SSD1306);
+	return true;
+}
+
+static bool wire_write(uint8_t byte) {
+	return Wire.write(byte);
+}
+
+static uint8_t wire_endTransmission(void) {
+	return Wire.endTransmission();
+}
+
+SSD1306Device oled(&wire_begin, &wire_beginTransmission, &wire_write, &wire_endTransmission);
+
+#endif


### PR DESCRIPTION
This adds compatibility with SoftI2CMaster (https://github.com/felias-fogg/SoftI2CMaster) library.
It is a software implementation of I2C and allows to use other pins than 0 and 2.